### PR TITLE
fix: do not interpret HTML in program source

### DIFF
--- a/lib/Devel/hdb/App/SourceFile.pm
+++ b/lib/Devel/hdb/App/SourceFile.pm
@@ -26,6 +26,11 @@ sub sourcefile {
         no warnings 'uninitialized';  # at program termination, the loaded file data can be undef
         no warnings 'numeric';        # eval-ed "sources" generate "not-numeric" warnings
         @rv = map { [ $_, $_ + 0 ] } @$file;
+
+        #hack to enable debugging code containing HTML
+        $_->[0] =~ s/&/&amp;/g for @rv;
+        $_->[0] =~ s/</&lt;/g for @rv;
+
         shift @rv;  # Get rid of the 0th element
     }
 


### PR DESCRIPTION
- quick hack to enable debugging programs containing HTML strings
- it's a hack but it might be still worth merging as it enables debugging some currently undebuggable programs
- fixes issue https://github.com/amb43790/Devel-hdb/issues/52
