### PR TITLE
Fix tests for OS X machines with IPv6 enabled.

### DIFF
--- a/t/HdbHelper.pm
+++ b/t/HdbHelper.pm
@@ -85,9 +85,9 @@ sub start_test_program {
     $HdbHelper::child_pid = $pid;
 
     if (wantarray) {
-        return ("http://localhost:${port}/", $pid, $program_file);
+        return ("http://127.0.0.1:${port}/", $pid, $program_file);
     } else {
-        return "http://localhost:${port}/";
+        return "http://127.0.0.1:${port}/";
     }
 }
 


### PR DESCRIPTION
The tests are currently failing hard on my mac, lots of connection refused errors:

```
t/01-load-debugger-html.t ......... Can't get debugger gui': Can't connect to localhost:62106 (Connection refused)    # Child (Main debugger page) exited without calling finalize()
```

Changing the url from localhost to 127.0.0.1 fixed the test suite for me.
