### PR TITLE
fix display of exit code on program termination; correct Client docs

### DIFF
--- a/lib/Devel/hdb/Client.pm
+++ b/lib/Devel/hdb/Client.pm
@@ -1086,7 +1086,7 @@ When the debugged program has finished.  The debugger is still running.
 
 =over 2
 
-=item exit_code
+=item value
 
 The process exit code
 

--- a/lib/Devel/hdb/html/debugger.html
+++ b/lib/Devel/hdb/html/debugger.html
@@ -132,7 +132,7 @@
         <div class="modal">
             <div class="modal-header">Program Terminated</div>
             <div class="modal-body">
-                Debugged program terminated with exit code {{exit_code}}
+                Debugged program terminated with exit code {{value}}
             </div>
             <div class="modal-footer">
                 <button class="btn btn-primary" data-dismiss="modal" value="ok">Ok</button>


### PR DESCRIPTION
The client and UI aren't referencing the right var to get a program's exit code following the aug. REST API work.
Corrected in favor of the REST API naming (exit event with a 'value' field).