### PR TITLE
Child process listen socket tries to use original port + 1

### DIFF
--- a/lib/Devel/hdb/App.pm
+++ b/lib/Devel/hdb/App.pm
@@ -70,6 +70,30 @@ sub _make_listen_socket {
         $server_params{server_ready} = sub { $self->init_debugger };
     }
 
+    if (exists($server_params{port}) and !defined($server_params{port}) and $self->{server}) {
+        # This was a forked child process
+        # try making a new listen socket that's 1 port higher
+        my $current_local_addr = $self->{server}->{listen_sock}->sockhost;
+        my $current_port = $self->{server}->{listen_sock}->sockport;
+        my $new_sock;
+        for(my $tries = 1; !$new_sock && $tries < 20; $tries++) {
+            $new_sock = IO::Socket::INET->new(Listen => 5,
+                                              LocalAddr => $current_local_addr,
+                                              LocalPort => $current_port + $tries,
+                                              Proto => 'tcp',
+                                              ReuseAddr => 1);
+        }
+        if ($new_sock) {
+            $server_params{listen_sock} = $new_sock;
+            delete $server_params{port};
+        } else {
+            local($SIG{__WARN__});
+            warn 'Could not find an open TCP port between '
+                    . ($current_port + 1) . ' and ' . ($current_port + 20)
+                    . " for child process $$. Letting the system pick one...";
+        }
+    }
+
     $Devel::hdb::LISTEN_SOCK = undef;
     $self->{server} = Devel::hdb::Server->new( %server_params );
 }


### PR DESCRIPTION
After a fork() the child process tries to open it's own listen socket by
bumping the parent process's port up by 1.  It uses a window of 20 to keep
trying to find an open one.

If it can't, it gives up and lets the system pick one for us.

This fixes #101