### PR TITLE
Allow composite objects to not actually be references

### DIFF
--- a/lib/Devel/hdb/html/perlvalue.js
+++ b/lib/Devel/hdb/html/perlvalue.js
@@ -290,7 +290,10 @@ PerlValue.prototype.refHeaderString = function() {
     if (this.blessed) {
         html += this.blessed + '=';
     }
-    html += this.type + '(0x' + this.refaddr.toString(16) + ')';
+    html += this.type;
+    if (this.refaddr) {
+        html += '(0x' + this.refaddr.toString(16) + ')';
+    }
     return html;
 }
 PerlValue.prototype.renderHeader = function(view) { return '' };


### PR DESCRIPTION
This allows displaying non-ref GLOBs in stashes.  Since they're not references,
they won't have refaddr data

Along with the latest Data::Transform::ExplicitMetadata, this fixes #61 