### PR TITLE
fix #112: encode file source url for /source

### DIFF
--- a/lib/Devel/hdb/html/restinterface.js
+++ b/lib/Devel/hdb/html/restinterface.js
@@ -50,7 +50,7 @@ function RestInterface(base_url) {
     };
 
     this.fileSourceAndBreakable = function(filename) {
-        return this._GET('source/' + filename, undefined);
+        return this._GET('source/' + encodeURIComponent(filename), undefined);
     };
 
     this.exit = function() {


### PR DESCRIPTION
This is a fix for #112 . You need to encode url for /source, otherwise "/" in filename would be taken as url path separator. 