### PR TITLE
Workaround perl bug by breaking on another line

### DIFF
--- a/t/04-get-all-breakpoints.t
+++ b/t/04-get-all-breakpoints.t
@@ -36,15 +36,15 @@ ok($bp_5, 'Set breakpoint line 5');
 
 my($test_nothing_file) = grep { $_->{filename} =~ m/TestNothing.pm/ } @{$client->loaded_files()};
 $test_nothing_file = $test_nothing_file->{filename};
-my $bp_tn = $client->create_breakpoint( filename => $test_nothing_file, line => 3 );
-ok($bp_tn, 'Set breakpoint for line TestNothing.pm 3');
+my $bp_tn = $client->create_breakpoint( filename => $test_nothing_file, line => 6 );
+ok($bp_tn, 'Set breakpoint for line TestNothing.pm 6');
 
 $resp = $client->get_breakpoints();
 is_deeply(sort_breakpoints_by_file_and_line($resp),
     [   { filename => $filename, line => 3, code => '$a', inactive => 0, href => $bp_3 },
         { filename => $filename, line => 4, code => 1, inactive => 1, href => $bp_4 },
         { filename => $filename, line => 5, code => 1, inactive => 0, href => $bp_5 },
-        { filename => $test_nothing_file, line => 3, code => 1, inactive => 0, href => $bp_tn },
+        { filename => $test_nothing_file, line => 6, code => 1, inactive => 0, href => $bp_tn },
     ],
     'Got all set breakpoints'
 );


### PR DESCRIPTION
There seems to be a bug in perl where setting a breakpoint on a line in the
top-level scope of a module can cause a segfault.  It only crashes rarely, so
the test needs to be run over and over to get it to trigger the problem.

Setting the breakpoint to a line within a sub of the module doesn't seem
to trigger the bug.

There's some commentary in https://github.com/brummett/Devel-hdb/issues/115
and some discussion in https://rt.perl.org/Public/Bug/Display.html?id=133271
Here's the important part:
    Building perl with clang and address sanitizer gives a consistent failure
    of t/04-get-all-breakpoints.t under bleadperl. The perl process running
    under -d:hdb is crashing. The crash is happening in the set magic for a
    %dbline element (Perl_magic_setdbline()), where pointers to ops are
    stored as the IV value in the magic's object SV; in this particular case,
    the op pointer is a pointer to an op that has already been freed.

    The set magic is triggered by this line in Devel/Chitin/Actionable.pm:
        sub _insert {
        ...
        my $bp_info = $dbline{$self->line} ||= {};

    where $self->line is 3 and $self->file is t/TestNothing.pm. In this case
    it's assigning {} to $dbline{3}.

    The op it's trying to update was created during the compilation of a
    require'd file, and the execution of the require has already finished
    and its associated op tree freed.

    Whether perl has freed the optree too soon, or whether hdb/Chitin is
    trying modify part of %dline that it shouldn't be, I don't know.