### PR TITLE
Load png files with binmode on

### DIFF
--- a/lib/Devel/hdb/App/Assets.pm
+++ b/lib/Devel/hdb/App/Assets.pm
@@ -31,6 +31,9 @@ sub assets {
         $type = 'text/html';
     } elsif ($file =~ m/\.css$/) {
         $type = 'text/css';
+    } elsif ( $file =~ m/\.png$/) {
+        $type = 'image/png';
+        $fh->binmode();
     } else {
         $type = 'text/plain';
     }


### PR DESCRIPTION
This was causing problems on Windows machines where the icons weren't visible.
The glyphicons file from Bootstrap contains a "0D 0A" sequence that gets
changed to "0A" on a Windows machine.