### PR TITLE
Save/load watched expressions along with breakpoints

### DIFF
--- a/lib/Devel/hdb/App.pm
+++ b/lib/Devel/hdb/App.pm
@@ -376,7 +376,7 @@ sub load_settings_from_file {
         push @set_breakpoints,
             Devel::hdb::App::Action->set_and_respond($self, $action);
     }
-    return 1;
+    return $settings;
 }
 
 sub save_settings_to_file {

--- a/lib/Devel/hdb/App.pm
+++ b/lib/Devel/hdb/App.pm
@@ -382,6 +382,7 @@ sub load_settings_from_file {
 sub save_settings_to_file {
     my $self = shift;
     my $file = shift;
+    my $additional = shift;
 
     unless (defined $file) {
         $file = $self->settings_file();
@@ -396,7 +397,7 @@ sub save_settings_to_file {
     my @breakpoints = map { $serializer->($_) } $self->get_breaks();
     my @actions = map { $serializer->($_) } $self->get_actions();
     my $fh = IO::File->new($file, 'w') || die "Can't open $file for writing: $!";
-    my $config = { breakpoints => \@breakpoints, actions => \@actions };
+    my $config = { breakpoints => \@breakpoints, actions => \@actions, additional => $additional };
     $fh->print( Data::Dumper->new([ $config ])->Terse(1)->Dump());
     return $file;
 }

--- a/lib/Devel/hdb/App/Config.pm
+++ b/lib/Devel/hdb/App/Config.pm
@@ -23,7 +23,7 @@ sub loadconfig {
     } elsif ($settings) {
         return [ 200,
                 ['Content-Type' => 'application/json'],
-                [ $app->encode_json($settings->{additional}) ] ];
+                [ $app->encode_json($settings) ] ];
     } else {
         return [ 404,
                 [ 'Content-Type' => 'text/plain' ],

--- a/lib/Devel/hdb/App/Config.pm
+++ b/lib/Devel/hdb/App/Config.pm
@@ -14,14 +14,16 @@ sub loadconfig {
     my($class, $app, $env, $file) = @_;
 
     local $@;
-    my $result = eval { $app->load_settings_from_file($file) };
+    my $settings = eval { $app->load_settings_from_file($file) };
     if ($@) {
         return [ 400,
                 [ 'Content-Type' => 'text/plain' ],
                 [ $@ ] ];
 
-    } elsif ($result ) {
-        return [ 204, [], [] ];
+    } elsif ($settings) {
+        return [ 200,
+                ['Content-Type' => 'application/json'],
+                [ $app->encode_json($settings->{additional}) ] ];
     } else {
         return [ 404,
                 [ 'Content-Type' => 'text/plain' ],

--- a/lib/Devel/hdb/App/Config.pm
+++ b/lib/Devel/hdb/App/Config.pm
@@ -32,8 +32,11 @@ sub loadconfig {
 sub saveconfig {
     my($class, $app, $env, $file) = @_;
 
+    my $body = $class->_read_request_body($env);
+    my $additional = $app->decode_json($body);
+
     local $@;
-    $file = eval { $app->save_settings_to_file($file) };
+    $file = eval { $app->save_settings_to_file($file, $additional) };
     if ($@) {
         return [ 400,
                 [ 'Content-Type' => 'text/html' ],

--- a/lib/Devel/hdb/Client.pm
+++ b/lib/Devel/hdb/Client.pm
@@ -415,7 +415,7 @@ sub load_config {
     my $response = $self->_POST(join('/', 'loadconfig', $escaped_filename));
     _assert_success($response, "Loading config from $filename failed: " . $response->content);
 
-    return 1;
+    return $JSON->decode($response->content);
 }
 
 sub save_config {

--- a/lib/Devel/hdb/Client.pm
+++ b/lib/Devel/hdb/Client.pm
@@ -419,10 +419,10 @@ sub load_config {
 }
 
 sub save_config {
-    my($self, $filename) = @_;
+    my($self, $filename, $additional) = @_;
 
     my $escaped_filename = URI::Escape::uri_escape($filename);
-    my $response = $self->_POST(join('/', 'saveconfig', $escaped_filename));
+    my $response = $self->_POST(join('/', 'saveconfig', $escaped_filename), $additional);
     _assert_success($response, "Save config to $filename failed: " . $response->content);
 
     return 1;

--- a/lib/Devel/hdb/html/debugger.js
+++ b/lib/Devel/hdb/html/debugger.js
@@ -934,6 +934,17 @@ function Debugger(sel) {
         $filePane.remove();
     }
 
+    function _loadConfig_response_handler_for_saveLoadBreakpoints(settings) {
+        dbg.breakpointManager.sync();
+
+        if (settings['additional'] && settings['additional']['watch_expressions']) {
+            var watch_expressions = settings['additional']['watch_expressions'];
+            for (var i = 0; i < watch_expressions.length; i++) {
+                dbg.watchedExpressionManager.addExpression( watch_expressions[i], false);
+            }
+        }
+    }
+
     function saveLoadBreakpoints(e) {
         e.preventDefault();
         var isSave = $(e.currentTarget).attr('id') === 'save-breakpoints',
@@ -965,14 +976,7 @@ function Debugger(sel) {
                                 })
                             .done(function(settings) {
                                  if (! isSave) {
-                                    dbg.breakpointManager.sync();
-
-                                    if (settings['additional'] && settings['additional']['watch_expressions']) {
-                                        var watch_expressions = settings['additional']['watch_expressions'];
-                                        for (var i = 0; i < watch_expressions.length; i++) {
-                                            dbg.watchedExpressionManager.addExpression( watch_expressions[i], false);
-                                        }
-                                    }
+                                    _loadConfig_response_handler_for_saveLoadBreakpoints(settings)
                                 }
                             })
                             .always(function() {

--- a/lib/Devel/hdb/html/debugger.js
+++ b/lib/Devel/hdb/html/debugger.js
@@ -951,8 +951,14 @@ function Debugger(sel) {
                     e.preventDefault();
                     var savefile = $(e.target).find('[name=filename]').val(),
                         ri_method = restInterface[isSave ? 'saveConfig' : 'loadConfig'];
+                        additional = {};
 
-                    ri_method.call(restInterface, savefile)
+                    if (isSave) {
+                        additional['watch_expressions'] = dbg.watchedExpressionManager.expressions();
+                        console.log(additional);
+                    }
+
+                    ri_method.call(restInterface, savefile, additional)
                              .fail(function(jqxhr, text_status, error_thrown) {
                                 alert((isSave ? 'Saving' : 'Loading')
                                         + ' config failed: ' + error_thrown);

--- a/lib/Devel/hdb/html/debugger.js
+++ b/lib/Devel/hdb/html/debugger.js
@@ -945,12 +945,17 @@ function Debugger(sel) {
         }
     }
 
+    this.defaultConfigFileName = function() {
+        return this.programName + '.hdb';
+    };
+
     function saveLoadBreakpoints(e) {
         e.preventDefault();
         var isSave = $(e.currentTarget).attr('id') === 'save-breakpoints',
+            savefile = dbg.defaultConfigFileName(),
             modal = $(this.templates.saveLoadBreakpointsModal({
                                             action: isSave ? 'Save' : 'Load',
-                                            filename: this.programName + '.hdb'
+                                            filename: savefile
                                         }));
         modal.appendTo($elt)
              .modal({ backdrop: true, keyboard: true, show: true })
@@ -960,8 +965,7 @@ function Debugger(sel) {
         modal.find('form')
              .submit(function(e) {
                     e.preventDefault();
-                    var savefile = $(e.target).find('[name=filename]').val(),
-                        ri_method = restInterface[isSave ? 'saveConfig' : 'loadConfig'];
+                    var ri_method = restInterface[isSave ? 'saveConfig' : 'loadConfig'];
                         additional = {};
 
                     if (isSave) {

--- a/lib/Devel/hdb/html/debugger.js
+++ b/lib/Devel/hdb/html/debugger.js
@@ -963,9 +963,13 @@ function Debugger(sel) {
                                 alert((isSave ? 'Saving' : 'Loading')
                                         + ' config failed: ' + error_thrown);
                                 })
-                            .done(function() {
+                            .done(function(additional_data) {
                                  if (! isSave) {
                                     dbg.breakpointManager.sync();
+
+                                    for (var i = 0; i < additional_data['watch_expressions'].length; i++) {
+                                        dbg.watchedExpressionManager.addExpression( additional_data['watch_expressions'][i], false);
+                                    }
                                 }
                             })
                             .always(function() {

--- a/lib/Devel/hdb/html/debugger.js
+++ b/lib/Devel/hdb/html/debugger.js
@@ -995,6 +995,13 @@ function Debugger(sel) {
             $elt.find('li#program-name a').html(program_name)
                                           .attr('title', program_name);
             dbg.programName = program_name;
+        })
+        .done(function() {
+            // This has to happen after the above where it sets the programName
+            dbg.restInterface.loadConfig(dbg.defaultConfigFileName())
+                            .done(function(settings) {
+                                _loadConfig_response_handler_for_saveLoadBreakpoints(settings);
+                            });
         });
     this.fileManager = new FileManager(this.restInterface);
 
@@ -1008,7 +1015,6 @@ function Debugger(sel) {
         .done(function(status) {
                 done_after_stack_update.call(dbg);
                 dbg.setCurrentStatementForCodeTable(status.next_statement);
-                dbg.breakpointManager.sync();
         });
 
     // Events

--- a/lib/Devel/hdb/html/debugger.js
+++ b/lib/Devel/hdb/html/debugger.js
@@ -963,12 +963,15 @@ function Debugger(sel) {
                                 alert((isSave ? 'Saving' : 'Loading')
                                         + ' config failed: ' + error_thrown);
                                 })
-                            .done(function(additional_data) {
+                            .done(function(settings) {
                                  if (! isSave) {
                                     dbg.breakpointManager.sync();
 
-                                    for (var i = 0; i < additional_data['watch_expressions'].length; i++) {
-                                        dbg.watchedExpressionManager.addExpression( additional_data['watch_expressions'][i], false);
+                                    if (settings['additional'] && settings['additional']['watch_expressions']) {
+                                        var watch_expressions = settings['additional']['watch_expressions'];
+                                        for (var i = 0; i < watch_expressions.length; i++) {
+                                            dbg.watchedExpressionManager.addExpression( watch_expressions[i], false);
+                                        }
                                     }
                                 }
                             })

--- a/lib/Devel/hdb/html/restinterface.js
+++ b/lib/Devel/hdb/html/restinterface.js
@@ -103,8 +103,8 @@ function RestInterface(base_url) {
         return this._POST('loadconfig/' + filename);
     };
 
-    this.saveConfig = function(filename) {
-        return this._POST('saveconfig/' + filename);
+    this.saveConfig = function(filename, additional) {
+        return this._POST('saveconfig/' + filename, additional);
     };
 
     ['stepin','stepout','stepover','continue','exit'].forEach(function(action) {

--- a/lib/Devel/hdb/html/watchedexprmanager.js
+++ b/lib/Devel/hdb/html/watchedexprmanager.js
@@ -8,6 +8,12 @@ function WatchedExprManager(rest_api) {
         return (expr in watchedExpressionToDivId);
     }
 
+    this.expressions = function() {
+        console.log('getting expressions');
+        console.log(watchedExpressionToDivId);
+        return Object.keys(watchedExpressionToDivId);
+    }
+
     function exprForElt($elt) {
         var divId = $elt.closest('.watched-expression').attr('id');
         for (var expr in watchedExpressionToDivId) {

--- a/t/16-save-breakpoints.t
+++ b/t/16-save-breakpoints.t
@@ -13,7 +13,7 @@ use Test::More;
 if ($^O =~ m/^MS/) {
     plan skip_all => 'Test hangs on Windows';
 } else {
-    plan tests => 15;
+    plan tests => 16;
 }
 
 my $url = start_test_program();
@@ -34,17 +34,20 @@ ok($resp, 'set breakpoint');
 $resp = $client->create_action( filename => $filename, line => 4, code => '123', inactive => 1 );
 ok($resp, 'set action');
 
+my $additional_data = { one => 1, two => 2 };
 my $configfile = File::Temp::tmpnam();
-$resp = $client->save_config($configfile);
+$resp = $client->save_config($configfile, $additional_data);
 ok($resp, 'save config');
 ok(-f $configfile, 'Config file created');
 
 eval "END { unlink '$configfile' }";
 
-config_file_is_correct($configfile);
+config_file_is_correct($configfile, $additional_data);
 
 sub config_file_is_correct {
     my $file = shift;
+    my $additional_data = shift;
+
     my $fh = IO::File->new($file, 'r') || die "Can't load $file: $!";
     local($/);
     my $content = <$fh>;
@@ -64,6 +67,8 @@ sub config_file_is_correct {
     is( $action->{code}, 123, '    action code');
     is( $action->{line}, 4, '    on line 4');
     is( $action->{filename}, $filename, "    of $filename");
+
+    is_deeply($config->{additional}, $additional_data, 'additional_data');
 }
 
     


### PR DESCRIPTION
The config file written by the "save breakpoints" button now also saves the list of watched expressions, and re-loads this list when the file is loaded.  It also restores the watched expressions when the debugger is first loaded, if the default saved-filename is used.

This fixes #125 