### PR TITLE
Add argument 'launch'

### DIFF
--- a/lib/Devel/hdb.pm
+++ b/lib/Devel/hdb.pm
@@ -34,10 +34,7 @@ sub import {
             our $LISTEN_SOCK = IO::Socket::INET->new();
             $LISTEN_SOCK->fdopen($1, 'r');
         } elsif ($param =~ m/\Alaunch(:(.+))?/) {
-	    our $LAUNCH = $1 ? $2 : do {
-		require Browser::Open;
-		Browser::Open::open_browser_cmd();
-	    };
+	    our $LAUNCH = $1 ? $2 : _get_default_launch_command();
 	}
 
     }
@@ -55,6 +52,19 @@ sub import {
 
     $self->attach();
 }
+
+sub _get_default_launch_command {
+    local $@ = undef;
+    my $cmd = eval {
+	require Browser::Open;
+	Browser::Open::open_browser_cmd();
+    } or warn <<'EOD';
+Unable to default launch command; can not load Browser::Open.
+You can still debug by launching the browser manually.
+EOD
+    return $cmd;
+}
+
 1;
 __END__
 

--- a/lib/Devel/hdb.pm
+++ b/lib/Devel/hdb.pm
@@ -58,9 +58,8 @@ sub _get_default_launch_command {
     my $cmd = eval {
 	require Browser::Open;
 	Browser::Open::open_browser_cmd();
-    } or warn <<'EOD';
+    } or die <<'EOD';
 Unable to default launch command; can not load Browser::Open.
-You can still debug by launching the browser manually.
 EOD
     return $cmd;
 }

--- a/lib/Devel/hdb.pm
+++ b/lib/Devel/hdb.pm
@@ -33,7 +33,12 @@ sub import {
         } elsif ($param =~ m/listenfd:(\d+)/) {
             our $LISTEN_SOCK = IO::Socket::INET->new();
             $LISTEN_SOCK->fdopen($1, 'r');
-        }
+        } elsif ($param =~ m/\Alaunch(:(.+))?/) {
+	    our $LAUNCH = $1 ? $2 : do {
+		require Browser::Open;
+		Browser::Open::open_browser_cmd();
+	    };
+	}
 
     }
 
@@ -81,6 +86,15 @@ start it like this:
 To specify a particular IP address to listen on:
 
     perl -d:hdb=host:192.168.0.123 yourprogram.pl
+
+To launch the browser automatically:
+
+    perl -d:hdb=launch:xdg-open yourprogram.pl
+
+where the argument to C<launch> is the command to open a URL. If you have
+L<Browser::Open|Browser::Open> installed, you can omit the argument:
+
+    perl -d:hdb=launch yourprogram.pl
 
 And to listen on any interface:
 

--- a/lib/Devel/hdb/App.pm
+++ b/lib/Devel/hdb/App.pm
@@ -89,6 +89,7 @@ sub _make_listen_socket {
 
     $Devel::hdb::LISTEN_SOCK = undef;
     $self->{server} = Devel::hdb::Server->new( %server_params );
+
 }
 
 sub _open_new_listen_sock_after_fork {
@@ -150,6 +151,9 @@ sub init_debugger {
 
     local $@;
     eval { $self->load_settings_from_file() };
+
+    system { $Devel::hdb::LAUNCH } $Devel::hdb::LAUNCH, $self->_gui_url()
+	if defined $Devel::hdb::LAUNCH;
 
 }
 

--- a/lib/Devel/hdb/App.pm
+++ b/lib/Devel/hdb/App.pm
@@ -162,10 +162,7 @@ sub init_debugger {
 		$error = sprintf '%s exited with error %d',
 		    $Devel::hdb::LAUNCH, $? >> 8;
 	    }
-	    warn <<"EOD";
-$error.
-You can still debug by launching the browser manually.
-EOD
+	    die "$error\n";
 	}
 
     }

--- a/lib/Devel/hdb/App.pm
+++ b/lib/Devel/hdb/App.pm
@@ -152,8 +152,23 @@ sub init_debugger {
     local $@;
     eval { $self->load_settings_from_file() };
 
-    system { $Devel::hdb::LAUNCH } $Devel::hdb::LAUNCH, $self->_gui_url()
-	if defined $Devel::hdb::LAUNCH;
+    if ( defined $Devel::hdb::LAUNCH ) {
+	system { $Devel::hdb::LAUNCH } $Devel::hdb::LAUNCH, $self->_gui_url();
+	if ( $? ) {
+	    my $error;
+	    if ( -1 == $? ) {
+		$error = "Unable to start program $Devel::hdb::LAUNCH";
+	    } else {
+		$error = sprintf '%s exited with error %d',
+		    $Devel::hdb::LAUNCH, $? >> 8;
+	    }
+	    warn <<"EOD";
+$error.
+You can still debug by launching the browser manually.
+EOD
+	}
+
+    }
 
 }
 


### PR DESCRIPTION
If specified, this argument attempts to launch a browser on the
debugger's port. The value of the argument is the name of the browser to
launch. If the argument is omitted, Browser::Open is loaded, and its
favored browser is used. If the attempt to load Browser::Open fails, an
exception is raised.