### PR TITLE
Remove kludge for eval frame "args"

### DIFF
--- a/lib/Devel/hdb/App/Stack.pm
+++ b/lib/Devel/hdb/App/Stack.pm
@@ -113,8 +113,6 @@ sub _serialize_frame {
 
     if ($exclude_sub_params) {
         $frame{args} = undef;
-    } elsif ($frame{subroutine} eq '(eval)') {
-        $frame{args} = [];
     } else {
         my @encoded_args = map { encode($_) } @{$frame{args}};
         $frame{args} = \@encoded_args;


### PR DESCRIPTION
This is fixed in Devel::Chitin's stack frame handling, commit f3c5bdd038b.

Eval frames' args were actually the enclosing sub's args, but they're
being stripped out in Devel::Chitin now for eval frames because they don't
have args.

This fixes #88