### PR TITLE
Make the breakpoint pane sorted

### DIFF
--- a/lib/Devel/hdb/html/breakpointmanager.js
+++ b/lib/Devel/hdb/html/breakpointmanager.js
@@ -114,13 +114,33 @@ function BreakpointManager($main_elt, rest_interface) {
         $existingElts.find('.bpaction-code').html(breakpointConditionTemplate({condition: bp.code}));
 
         if ($eltsInBreakpointList.length == 0) {
-            // Add a new list item to the bottom of the list
+            // Need to add a new item to the list
             var params = type == 'breakpoint'
                             ? {condition: bp.code, conditionEnabled: ! bp.inactive}
                             : {action: bp.code, actionEnabled: ! bp.inactive};
             params.filename = bp.filename;
             params.lineno = bp.line;
-            $breakpointsList.append( breakpointPaneItemTemplate(params));
+            newBPItem = breakpointPaneItemTemplate(params);
+
+            // Insert it into the correct position be findinh an item that
+            // would sort after this new item.  First sort by filename, then
+            // by lineno
+            var found = false;
+            $breakpointsList.children().each( function( index, el ) {
+                $el = $(el);
+                if (! found
+                    && (   ( $el.attr('data-filename') > filename )
+                        || ( $el.attr('data-filename') == filename && Number($el.attr('data-lineno')) > line ) )
+                ) {
+                    found = true
+                    $el.before(newBPItem);
+                }
+            })
+
+            // Didn't find a place to insert it.  Put it at the end
+            if ( ! found) {
+                $breakpointsList.append( newBPItem );
+            }
         }
     }
 

--- a/lib/Devel/hdb/html/debugger.js
+++ b/lib/Devel/hdb/html/debugger.js
@@ -1006,6 +1006,7 @@ function Debugger(sel) {
     this.fileManager = new FileManager(this.restInterface);
 
     this.breakpointManager = new BreakpointManager(this.$elt, this.restInterface);
+    this.breakpointManager.sync();
     this.watchedExpressionManager = new WatchedExprManager(this.restInterface);
     this.watchedExpressionManager.loadWatchpoints();
 


### PR DESCRIPTION
Breakpoints are sorted by filename, then by lineno

It also fixes a bug where breakpoints in the running program weren't synced with the gui when reloading the page

This fixes #67